### PR TITLE
Add InheritedNotCsrfProtected annotation

### DIFF
--- a/src/main/java/org/apache/tapestry5/csrfprotection/InheritedNotCsrfProtected.java
+++ b/src/main/java/org/apache/tapestry5/csrfprotection/InheritedNotCsrfProtected.java
@@ -18,6 +18,6 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 @Inherited
-public @interface InheritableNotCsrfProtected
+public @interface InheritedNotCsrfProtected
 {
 }

--- a/src/main/java/org/apache/tapestry5/csrfprotection/internal/ProtectedPagesService.java
+++ b/src/main/java/org/apache/tapestry5/csrfprotection/internal/ProtectedPagesService.java
@@ -2,7 +2,7 @@ package org.apache.tapestry5.csrfprotection.internal;
 
 import org.apache.tapestry5.csrfprotection.CsrfConstants;
 import org.apache.tapestry5.csrfprotection.CsrfProtectionMode;
-import org.apache.tapestry5.csrfprotection.InheritableNotCsrfProtected;
+import org.apache.tapestry5.csrfprotection.InheritedNotCsrfProtected;
 import org.apache.tapestry5.csrfprotection.NotCsrfProtected;
 import org.apache.tapestry5.ioc.annotations.Value;
 import org.apache.tapestry5.ioc.internal.util.TapestryException;
@@ -41,7 +41,7 @@ public class ProtectedPagesService
 
         Class<?> pageClass = getPageClass(parameters);
         return !(pageClass.isAnnotationPresent(NotCsrfProtected.class)
-        || pageClass.isAnnotationPresent(InheritableNotCsrfProtected.class));
+        || pageClass.isAnnotationPresent(InheritedNotCsrfProtected.class));
     }
 
     private Class<?> getPageClass(ComponentEventRequestParameters parameters)


### PR DESCRIPTION
This annotation does the same as the NotCsrfProtected annotation, but is inherited to all sub classes of the annotated class (the original annotation is not). This is useful, if you use an (abstract) base class for a subset of your Tapestry pages.

This should not be the default, so I kept the NotCsrfProtected annotation as well.
