### PR TITLE
Make CsrfToken extend java.io.Serializable & remove runtime dependency on Spring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings/
 target
 /
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 			<groupId>net.sourceforge.tapestryxpath</groupId>
 			<artifactId>tapestry-xpath</artifactId>
 			<version>1.0.1</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.tapestry</groupId>

--- a/src/main/java/org/apache/tapestry5/csrfprotection/CsrfToken.java
+++ b/src/main/java/org/apache/tapestry5/csrfprotection/CsrfToken.java
@@ -1,12 +1,14 @@
 package org.apache.tapestry5.csrfprotection;
 
+import java.io.Serializable;
+
 /**
  * Provides the information about an expected CSRF token.
  *
  * @see org.apache.tapestry5.csrfprotection.internal.DefaultCsrfToken
  * @since 1.1
  */
-public interface CsrfToken
+public interface CsrfToken extends Serializable
 {
     /**
      * Gets the HTTP header that the CSRF is populated on the response and can

--- a/src/main/java/org/apache/tapestry5/csrfprotection/internal/SpringContextHelper.java
+++ b/src/main/java/org/apache/tapestry5/csrfprotection/internal/SpringContextHelper.java
@@ -1,8 +1,9 @@
 package org.apache.tapestry5.csrfprotection.internal;
 
 import org.apache.tapestry5.ioc.ObjectLocator;
-import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
+
+import java.lang.reflect.Method;
 
 /**
  * Util class for getting Spring beans.
@@ -36,10 +37,11 @@ public final class SpringContextHelper
             return null;
         }
 
-        ApplicationContext applicationContext;
+        // org.springframework.context.ApplicationContext
+        Object applicationContext;
         try
         {
-            applicationContext = (ApplicationContext) objectLocator.getService(springAppContextClass);
+            applicationContext = objectLocator.getService(springAppContextClass);
         }
         catch (RuntimeException e)
         {
@@ -48,9 +50,10 @@ public final class SpringContextHelper
 
         try
         {
-            return applicationContext.getBean(beanTypeClass);
+            Method getBean = applicationContext.getClass().getMethod("getBean", Class.class);
+            return getBean.invoke(applicationContext, beanTypeClass);
         }
-        catch (BeansException e)
+        catch (Exception e)
         {
             return null;
         }


### PR DESCRIPTION
- Make CsrfToken extend java.io.Serializable

  This is needed for distributed/clustered sessions

- Make Spring dependency optional

  Compiled class `SpringContextHelper` still depends on the `org.springframework.beans.BeansException` resulting in `ClassNotFoundException` at runtime