### PR TITLE
Switch to Tapestry 5.4, Spring 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .classpath
 .project
 .settings/
+build/
 target/
 .idea/
 *.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
+branches:
+  only:
+    - master

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 		<tag>HEAD</tag>
 	</scm>
 	<properties>
-		<tapestry-release-version>5.4.4</tapestry-release-version>
+		<tapestry-release-version>5.6.0</tapestry-release-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 	</properties>
@@ -49,7 +49,7 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
-			<version>5.1.5.RELEASE</version>
+			<version>5.3.4.RELEASE</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>at.porscheinformatik.tapestry</groupId>
 	<artifactId>tapestry-csrf-protection</artifactId>
-	<version>1.3.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Tapestry CSRF Protection</name>
 	<description>Cross-Site-Request-Forgery (CSRF) protection for Apache Tapestry 5.
@@ -36,9 +36,9 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 		<tag>HEAD</tag>
 	</scm>
 	<properties>
-		<tapestry-release-version>5.3.8</tapestry-release-version>
+		<tapestry-release-version>5.4.4</tapestry-release-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.7</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -49,13 +49,13 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-web</artifactId>
-			<version>[3.2,)</version>
+			<version>5.1.5.RELEASE</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -69,6 +69,12 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 			<artifactId>tapestry-test</artifactId>
 			<version>${tapestry-release-version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
+          <scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/test/java/at/porscheinformatik/tapestry/csrfprotection/internal/CsrfTokenManagerTest.java
+++ b/src/test/java/at/porscheinformatik/tapestry/csrfprotection/internal/CsrfTokenManagerTest.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 public class CsrfTokenManagerTest
 {
-    private TestableRequest request = new TestableRequestImpl();
+    private TestableRequest request = new TestableRequestImpl("/");
 
     @Test
     public void noTokenNewSession()

--- a/src/test/java/at/porscheinformatik/tapestry/csrfprotection/tests/auto/AjaxFormLoopTest.java
+++ b/src/test/java/at/porscheinformatik/tapestry/csrfprotection/tests/auto/AjaxFormLoopTest.java
@@ -1,24 +1,25 @@
 package at.porscheinformatik.tapestry.csrfprotection.tests.auto;
 
-import java.util.List;
+import static org.testng.Assert.assertTrue;
 
-import at.porscheinformatik.tapestry.csrfprotection.CsrfConstants;
-import at.porscheinformatik.tapestry.csrfprotection.services.CsrfProtectionModule;
-import at.porscheinformatik.tapestry.csrfprotection.tests.auto.services.AutoModeModule;
+import java.util.List;
 
 import org.apache.tapestry5.dom.Document;
 import org.apache.tapestry5.dom.Element;
 import org.apache.tapestry5.test.PageTester;
 import org.jaxen.JaxenException;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.formos.tapestry.xpath.TapestryXPath;
 
+import at.porscheinformatik.tapestry.csrfprotection.CsrfConstants;
+import at.porscheinformatik.tapestry.csrfprotection.services.CsrfProtectionModule;
+import at.porscheinformatik.tapestry.csrfprotection.tests.auto.services.AutoModeModule;
+
 /**
  * Tests the BeanEditForm in combination with the cross-site request forgery protection.
  */
-public class AjaxFormLoopTest extends Assert
+public class AjaxFormLoopTest
 {
 
     /**
@@ -36,12 +37,12 @@ public class AjaxFormLoopTest extends Assert
         org.apache.tapestry5.dom.Document doc = tester.renderPage("AjaxFormLoop");
         // simple test, just checking if the event link rendered in javascript contains the anti CSRF token
         assertTrue(
-            doc.toString().contains("/foo/ajaxformloop.ajaxformloop:triggerremoverow/bla?" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME),
+            doc.toString().contains("/ajaxformloop.ajaxloop:triggerremoverow?" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME),
             "The antiCsrfToken parameter is not present for the event link rendered in JavaScript by the RemoveRowLink component.");
 
         // the link created by the AddRowLink component should also contain the anti CSRF token
         assertTrue(
-            doc.toString().contains("/foo/ajaxformloop.ajaxformloop.rowinjector:inject?" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME),
+            doc.toString().contains("/ajaxformloop.ajaxloop:injectrow?" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME),
             "The antiCsrfToken parameter is not present for the event link rendered in JavaScript by the AddRowLink component.");
     }
 
@@ -74,8 +75,8 @@ public class AjaxFormLoopTest extends Assert
 
         Element removeRowLink = selectElements.get(0);
         String href = removeRowLink.getAttribute("href");
-        href += "?" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME + "=" + token;
-        removeRowLink.attribute("href", href);
+        href += "&" + CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME + "=" + token;
+        removeRowLink.forceAttributes("href", href);
         Document response = tester.clickLink(removeRowLink);
 
         assertTrue(response.toString().contains("A component event handler method returned the value {}"),

--- a/src/test/java/at/porscheinformatik/tapestry/csrfprotection/tests/off/AjaxFormLoopTest.java
+++ b/src/test/java/at/porscheinformatik/tapestry/csrfprotection/tests/off/AjaxFormLoopTest.java
@@ -1,23 +1,25 @@
 package at.porscheinformatik.tapestry.csrfprotection.tests.off;
 
 import static at.porscheinformatik.tapestry.csrfprotection.CsrfConstants.DEFAULT_CSRF_TOKEN_PARAMETER_NAME;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
-import at.porscheinformatik.tapestry.csrfprotection.util.PageTesterUtils;
 import org.apache.tapestry5.dom.Document;
 import org.apache.tapestry5.dom.Element;
 import org.apache.tapestry5.test.PageTester;
 import org.jaxen.JaxenException;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.formos.tapestry.xpath.TapestryXPath;
 
+import at.porscheinformatik.tapestry.csrfprotection.util.PageTesterUtils;
+
 /**
  * Tests the BeanEditForm in combination with the cross-site request forgery protection.
  */
-public class AjaxFormLoopTest extends Assert
+public class AjaxFormLoopTest
 {
     /**
      * A page that contains a form is tested. It should contain the CSRF protection token.

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/components/Layout.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/components/Layout.tml
@@ -11,7 +11,7 @@ Released   : 20080825
 Description: A Web 2.0 design with fluid width suitable for blogs and small websites.
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
     <head>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/AjaxFormLoop.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/AjaxFormLoop.tml
@@ -1,8 +1,8 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
-    <form t:type="form" t:id="ajaxLoop">
-    	<t:errors/>
+    <form t:type="form" t:id="AjaxLoopForm">
+		<t:errors />
     	<table>
 			<thead>
 				<tr>
@@ -10,7 +10,7 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr t:type="AjaxFormLoop" t:source="myList" t:value="testBean" t:encoder="encoder">				
+				<tr t:id="AjaxLoop" t:type="AjaxFormLoop" t:source="myList" t:value="testBean" t:encoder="encoder">
 					<t:submitnotifier>
 						<td><input t:type="TextField" t:id="testProperty" t:value="testBean.testProperty"/></td>
 						<td><t:removerowlink>remove</t:removerowlink></td>
@@ -19,12 +19,11 @@
 			</tbody>
 	 	</table>    
 	 </form>
-	 
-	<a id="removeRowLink" href="/foo/ajaxformloop.ajaxformloop:triggerremoverow/bla"/>
-   	<a id="addRowLink" href="/foo/ajaxformloop.ajaxformloop.rowinjector:inject"/>
-   	
-   	 <t:eventlink t:id="dummy" id="dummy">Dummy</t:eventlink>
+
+	<a id="removeRowLink" href="/ajaxformloop.ajaxloop:triggerremoverow?t:rowvalue=bla">Remove row</a>
+	<a id="addRowLink" href="/ajaxformloop.ajaxloop:injectrow">Add</a>
+
+	<t:eventlink t:id="dummy" id="dummy">Dummy</t:eventlink>
 </html>
 
 
- 

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/AjaxFormLoopAttack.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/AjaxFormLoopAttack.tml
@@ -1,5 +1,5 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
 	xmlns:p="tapestry:parameter">
-	<a id="removeRowLink" href="/foo/ajaxformloop.ajaxformloop:triggerremoverow/bla">Add</a>
-	<a id="addRowLink" href="/foo/ajaxformloop.ajaxformloop.rowinjector:inject">Remove</a>
+	<a id="removeRowLink" href="/ajaxformloop.ajaxformloop:triggerremoverow/bla">Add</a>
+	<a id="addRowLink" href="/ajaxformloop.ajaxformloop.rowinjector:inject">Remove</a>
 </html>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/BeanEditForm.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/BeanEditForm.tml
@@ -1,5 +1,5 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
     <t:beaneditform t:id="testbean"/>
 </html>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/BeanEditFormAttack.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/BeanEditFormAttack.tml
@@ -1,9 +1,9 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
-<form id="form" method="post" action="/foo/beaneditform.bean.form" onsubmit="javascript:return Tapestry.waitForPage(event);">
+<form id="form" method="post" action="/beaneditform.bean.form" onsubmit="javascript:return Tapestry.waitForPage(event);">
 	<input type="hidden" name="t:formdata" value="H4sIAAAAAAAAAFvzloG1XIpBwik1Mc81JbPELb8o1yoJyNFLBfLyi4qLGKzyi9L1EgsSkzNS9UoSC1KLS4oqTfWS84tSczKTgHRuQX5eal5JsR7MjPwilYCi1ILEotRwAT/u1RXbJJkYGCoKyuUZZHFZo5eTn18AtEuPWLt8gOpVjD4VpGm6i622p5H5xgc0WjyMv6xlgJivyaCO0/yCovyC1KKSSniouRNrUwBUJzTkglNLSgtc88oyi/LzcoEKvASZCu8b6+syMTD6MHDArClhEPLJSixL1M9JzEvXDy4pysxLt64oKGHgKQHaBDOyXJlBEWSjPrIdTjn5ydnFViWpFSVpmak5KUC3muJ1a1JicaqeYxJQMDG5xA2kBeJI1dDD3A9Fj/8Bu4w7OT+vpCg/xy8xN7WQoY6BnWzHOJLqGKB5yanFxcGlSbmZxcWZ+XmH16WYpH2bd46MWPMkM9acc4CmosRbbti+WgUP8d80SpomqEkffw52JSMHY/oo3ter82Ts5w6wjQBniEyGOAQAAA=="/>
 	<input type="text" name="testProperty" id="testProperty" value="test"/>
-	<img src="/foo/assets/1.0-SNAPSHOT/tapestry/spacer.gif" alt="" class="t-error-icon" id="testProperty_icon" style="display: none;"/><input type="submit" class="t-beaneditor-submit" value="Create/Update"/>
+	<img src="/assets/1.0-SNAPSHOT/tapestry/spacer.gif" alt="" class="t-error-icon" id="testProperty_icon" style="display: none;"/><input type="submit" class="t-beaneditor-submit" value="Create/Update"/>
 </form>
 </html>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/CsrfHidden.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/CsrfHidden.tml
@@ -1,4 +1,4 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
 	xmlns:p="tapestry:parameter">
 	<form action="/login">
 		This is a form for another framework
@@ -7,4 +7,3 @@
 </html>
 
 
- 

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Form.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Form.tml
@@ -1,5 +1,5 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
     <t:form t:id="messageForm">	
 		<t:textfield t:id="message"/>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/FormAttack.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/FormAttack.tml
@@ -1,14 +1,14 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
-<form onsubmit="javascript:return Tapestry.waitForPage(event);" action="/foo/form.messageform" method="post" id="messageForm">
+<form onsubmit="javascript:return Tapestry.waitForPage(event);" action="/form.messageform" method="post" id="messageForm">
 <div class="t-invisible">
 
 <input value="2188910186759187737" name="t:antiCsrfToken" type="hidden"></input>
 <input value="H4sIAAAAAAAAAFvzloG1nI+Bxy2/KNcqN7W4ODE9tbiIwTS/KF0vsSAxOSNVrySxILW4pKjSVC85vyg1JzNJLymxOFXPMQkomJhc4paZmpOiEpxaUlqgGnqY+6Ho8T9MDIw+DNzJ+XklRfk5fom5qSUMQj5ZiWWJ+jmJeen6wSVFmXnp1hUFJQzsUCuxOMGRVCcEFOUnA3UHlyblZhYXZ+bnHV6XYpL2bd45JgaGigIAs05usOkAAAA=" name="t:formdata" type="hidden"></input>
 </div>
 <input id="message" name="message" type="text"></input>
-<img id="message_icon" class="t-error-icon t-invisible" alt="" src="/foo/assets/1.0-SNAPSHOT/tapestry/spacer.gif"/><input value="Send" type="submit">
+<img id="message_icon" class="t-error-icon t-invisible" alt="" src="/assets/1.0-SNAPSHOT/tapestry/spacer.gif"/><input value="Send" type="submit">
 </input><br/>
 </form>	
 </html>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Links.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Links.tml
@@ -1,5 +1,5 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
      <t:beandisplay object="testBean"/>
         <p>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/LinksAttack.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/LinksAttack.tml
@@ -1,13 +1,13 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
      <p>
-<a id="actionLink" href="/foo/links.actionlink">ActionLink</a>
+<a id="actionLink" href="/links.actionlink">ActionLink</a>
 </p>
 <p>
-<a id="eventLink1" href="/foo/links:event">EventLink1</a>
+<a id="eventLink1" href="/links:event">EventLink1</a>
 </p>
-<p><a id="eventLink2" href="/foo/links:event">EventLink2</a></p>
+<p><a id="eventLink2" href="/links:event">EventLink2</a></p>
 </html>
 
 

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Unprotected.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/auto/pages/Unprotected.tml
@@ -1,5 +1,5 @@
 <html t:type="layout" title="testing Index"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
      <t:beandisplay object="testBean"/>
         <p>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/components/Layout.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/components/Layout.tml
@@ -11,7 +11,7 @@ Released   : 20080825
 Description: A Web 2.0 design with fluid width suitable for blogs and small websites.
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+      xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
       xmlns:p="tapestry:parameter">
     <head>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/AjaxFormLoop.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/AjaxFormLoop.tml
@@ -1,5 +1,6 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
-	xmlns:p="tapestry:parameter">
+<html t:type="layout" title="testing Index"
+	  xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
+	  xmlns:p="tapestry:parameter">
 	<form t:type="form" t:id="AjaxLoopForm">
 		<t:errors />
 		<table>
@@ -23,12 +24,11 @@
 		</table>
 	</form>
 
-	<a href="/foo/ajaxformloop.ajaxloop:triggerremoverow/bla" id="removeRowLink">Remove Row</a>
-	<a href="/foo/ajaxformloop.ajaxloop.rowinjector:inject?t:formcomponentid=AjaxFormLoop:ajaxloopform&amp;t:formid=AjaxLoopForm"
+	<a href="/ajaxformloop.ajaxloop:triggerremoverow?t:rowvalue=bla" id="removeRowLink">Remove Row</a>
+	<a href="/ajaxformloop.ajaxloop.rowinjector:inject?t:formcomponentid=AjaxFormLoop:ajaxloopform&amp;t:formid=AjaxLoopForm"
 		id="addRowLink">Add Row</a>
 
 	<t:eventlink t:id="dummy" id="dummy">Dummy</t:eventlink>
 </html>
 
 
- 

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/BeanEditForm.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/BeanEditForm.tml
@@ -1,4 +1,4 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
 	xmlns:p="tapestry:parameter">
 	<t:beaneditform t:id="testbean" />
 </html>

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/Form.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/Form.tml
@@ -1,4 +1,4 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
 	xmlns:p="tapestry:parameter">
 	<t:form t:id="messageForm">
 		<t:textfield t:id="message" />

--- a/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/Links.tml
+++ b/src/test/resources/at/porscheinformatik/tapestry/csrfprotection/tests/off/pages/Links.tml
@@ -1,4 +1,4 @@
-<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_1_0.xsd"
+<html t:type="layout" title="testing Index" xmlns:t="http://tapestry.apache.org/schema/tapestry_5_4.xsd"
 	xmlns:p="tapestry:parameter">
 	<t:beandisplay object="testBean" />
 	<p>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootCategory=WARN, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=[%p] %c{2} %m%n
-log4j.logger.org.apache.tapestry.csrfprotection=debug

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration debug="false">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="at.porscheinformatik.tapestry.csrfprotection" level="debug"/>
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
 - Increment version to 2.0.0-SNAPSHOT
 - Change to Java 8
 - Change to Tapestry 5.4.4
 - Use Spring Security Web 5.1.5.RELEASE