### PR TITLE
Snyk vulnerability can be fixed by updating to tapestry core 5.7 howe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>at.porscheinformatik.tapestry</groupId>
 	<artifactId>tapestry-csrf-protection</artifactId>
-	<version>3.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.2.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Tapestry CSRF Protection</name>
 	<description>Cross-Site-Request-Forgery (CSRF) protection for Apache Tapestry 5.
@@ -36,7 +36,7 @@ This project is based on the Google Summer of Code 2011 project done by Markus J
 		<tag>HEAD</tag>
 	</scm>
 	<properties>
-		<tapestry-release-version>5.7.2</tapestry-release-version>
+		<tapestry-release-version>5.6.4</tapestry-release-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 	</properties>


### PR DESCRIPTION
…ver for those on 5.6x we can update the 2.0.x release stream with latest 5.6.4 tapestry core version